### PR TITLE
Update makefile_include_opennet_packages.patch

### DIFF
--- a/patches/makefile_include_opennet_packages.patch
+++ b/patches/makefile_include_opennet_packages.patch
@@ -45,10 +45,10 @@ Index: on_firmware/openwrt/include/opennet.mk
 +endef
 +
 +define Build/Prepare
-+	mkdir -p $(PKG_BUILD_DIR)/lmo; $(TAR) c . \
++	mkdir -p $(PKG_BUILD_DIR)/lmo; $(TAR) c \
 +		--exclude=.pc --exclude=.svn --exclude=.git \
 +		--exclude='boa-0*' --exclude='*.o' --exclude='*.so' \
-+		--exclude=dist | \
++		--exclude=dist . | \
 +			$(TAR) x -C $(PKG_BUILD_DIR)/
 +	@# po2lmo bauen, falls nicht vorhanden
 +	[ -x "$(PO_CONV)" ] || make -C ../../../luci/modules/luci-base/src/ po2lmo


### PR DESCRIPTION
tar --exclude has to be first otherwise we get an error and no files will be excluded

tar: The following options were used after any non-optional arguments in archive create or update mode.  These options are positional and affect only arguments that follow them.  Please, rearrange them properly. tar: --exclude ‘.pc’ has no effect
...
tar: Exiting with failure status due to previous errors