### PR TITLE
remove trailing whitespace from patche

### DIFF
--- a/patches/packages-libpfring-fix-openwrt-23.05.patch
+++ b/patches/packages-libpfring-fix-openwrt-23.05.patch
@@ -16,9 +16,9 @@ index 000000000..c0a901797
 +   struct sock *sk = sock->sk;
 +-  char name[sizeof(sa->sa_data)+1];
 ++  char name[sizeof(sa->sa_data_min)+1];
-+ 
++
 +   debug_printk(2, "ring_bind() called\n");
-+ 
++
 +   /*
 +    * Check legality
 +    */
@@ -26,9 +26,9 @@ index 000000000..c0a901797
 +     return(-EINVAL);
 +   if(sa->sa_family != PF_RING)
 +     return(-EINVAL);
-+ 
++
 +-  memcpy(name, sa->sa_data, sizeof(sa->sa_data));
 ++  memcpy(name, sa->sa_data, sizeof(sa->sa_data_min));
-+ 
++
 +   /* Add trailing zero if missing */
 +   name[sizeof(name)-1] = '\0';


### PR DESCRIPTION
Der Patch packages-libpfring-fix-openwrt-23.05.patch konnte vom buildbot nicht mit quilt pop entfernt werden.
Ein quilt pop --refresh hat funktioniert mit der Meldung das Leerzeichen im patch vorhanden waren.
Diese hab ich mit dem pull request aus dem Patch entfernt.